### PR TITLE
point requestManager to use the topic id

### DIFF
--- a/src/utils/requestManager.js
+++ b/src/utils/requestManager.js
@@ -19,7 +19,7 @@ class Manager {
   publish() {
     return new Promise((resolve, reject) => {
       this._eventsource.publish(
-        new RequestTopic(this._client.deviceId).request,
+        new RequestTopic(this.topic.deviceId).request,
         this.request.toString(),
         err => {
           if (err) reject(err);


### PR DESCRIPTION
use the topic device id for requests rather then the parent 